### PR TITLE
COBRA-1922

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -129,9 +129,11 @@ async function hooks_update(pg_pool, req, res, regex) {
   if(typeof(payload.active) !== 'undefined' && payload.active !== true && payload.active !== false) {
     throw new common.BadRequestError('The specified payload active flag was neither true or false.')
   }
-  if(typeof(payload.secret) !== 'undefined'){
+  if(typeof(payload.secret) !== 'undefined' && typeof(payload.secret) === 'string'){
     payload.secret = common.encrypt_token(process.env.ENCRYPT_KEY, payload.secret);
-  } 
+  } else if (payload.secret){
+    throw new common.BadRequestError('The specified payload secret was not a string')
+  }
   let hooks = await update_hook(pg_pool, [hook_id, payload.events ? payload.events.join(',') : null, payload.url, payload.secret, payload.active])
   if (hooks.length === 0) {
     throw new common.NotFoundError(`The specified hook was not found.`)


### PR DESCRIPTION
If the API got a null value for the secret, it would try to encrypt null and throw an error. We were passing in a string with value null, but the value 'null' was now being encrypted... so this fixes it - now, if secret is NOT undefined AND is a string type, it encrypts it.