### PR TITLE
COBRA-1820

### DIFF
--- a/index.js
+++ b/index.js
@@ -359,7 +359,7 @@ routes.add.get('/addon-services/([A-z0-9\\-\\_\\.]+)$')
 routes.add.get('/addon-services/([A-z0-9\\-\\_\\.]+)/plans$')
           .run(alamo.addon_services.plans.list.bind(alamo.addon_services.plans.list, pg_pool))
           .and.authorization([simple_key]);
-routes.add.get('/addon-services/([A-z0-9\\-\\_\\.]+)/plans/([A-z0-9\\-\\_\\.]+)$')
+routes.add.get('/addon-services/([A-z0-9\\-\\_\\.]+)/plans/([A-z0-9\-\_\.\:]+)$')
           .run(alamo.addon_services.plans.get.bind(alamo.addon_services.plans.get, pg_pool))
           .and.authorization([simple_key]);
 

--- a/lib/addon-services.js
+++ b/lib/addon-services.js
@@ -114,17 +114,20 @@ async function plans_list(pg_pool, req, res, regex) {
 
 async function plans_get(pg_pool, req, res, regex) {
   let addon_id_or_name = httph.first_match(req.url, regex);
-  let plan_id = httph.second_match(req.url, regex);
+  let plan_id_or_name = httph.second_match(req.url, regex);
   let addon_info = addon_by_id_or_name(addon_id_or_name);
+  let plan = plan_by_id_or_name(plan_id_or_name);
+  /*
   let plans = addon_info.plans();
   let filtered_plans = plans.filter((plan) => { return plan.id === plan_id || plan.name.split(':')[1] === plan_id; });
-
+  
   if(filtered_plans.length === 0) {
     throw new common.NotFoundError('The specified plan was not found.');
   } else if (filtered_plans.length > 1) {
     throw new common.InternalServerError(null, 'An error occured, the specified addon id and plan mapped to multiple addon plans.')
   }
-  let results = await select_service_plan_apps(pg_pool, [plan_id]);
+  */
+  let results = await select_service_plan_apps(pg_pool, [plan.id]);
   let apps = results.map((app) => {return {"id":app.app, "name":`${app.name}-${app.space}`}});
   apps.sort((a,b) =>  ((a.name > b.name) ? 1 : ((b.name > a.name) ? -1 : 0)) ); 
   filtered_plans[0].provisioned_by = apps;

--- a/lib/addon-services.js
+++ b/lib/addon-services.js
@@ -116,18 +116,15 @@ async function plans_get(pg_pool, req, res, regex) {
   let addon_id_or_name = httph.first_match(req.url, regex);
   let plan_id_or_name = httph.second_match(req.url, regex);
   let addon_info = addon_by_id_or_name(addon_id_or_name);
-  let plan = plan_by_id_or_name(plan_id_or_name);
-  /*
   let plans = addon_info.plans();
-  let filtered_plans = plans.filter((plan) => { return plan.id === plan_id || plan.name.split(':')[1] === plan_id; });
-  
+  let filtered_plans = plans.filter((plan) => { return plan.id === plan_id_or_name || plan.name === plan_id_or_name});
+
   if(filtered_plans.length === 0) {
     throw new common.NotFoundError('The specified plan was not found.');
   } else if (filtered_plans.length > 1) {
     throw new common.InternalServerError(null, 'An error occured, the specified addon id and plan mapped to multiple addon plans.')
   }
-  */
-  let results = await select_service_plan_apps(pg_pool, [plan.id]);
+  let results = await select_service_plan_apps(pg_pool, [filtered_plans[0].id]);
   let apps = results.map((app) => {return {"id":app.app, "name":`${app.name}-${app.space}`}});
   apps.sort((a,b) =>  ((a.name > b.name) ? 1 : ((b.name > a.name) ? -1 : 0)) ); 
   filtered_plans[0].provisioned_by = apps;


### PR DESCRIPTION
/addon-services/[addon]/plans/[plan] now allows you to pass in plan ID or name, not just plan ID

Plan regex now allows colons (/addon-services/[addon regex]/plans/[plan regex]) to account for plan names such as alamo-mongodb:shared