### PR TITLE
COBRA-2286 - disable attachments by name

### DIFF
--- a/docs/API-Reference.md
+++ b/docs/API-Reference.md
@@ -55,6 +55,7 @@ curl \
   },
   "created_at":"2016-07-18T14:55:38.190Z",
   "git_url":"",
+  "git_branch":"",
   "id":"4f739e5e-4cf7-11e6-beb8-9e71128cae77",
   "maintenance":false,
   "name":"events",
@@ -521,7 +522,7 @@ To get an existing apps blue print it can be fetched and subsequently modifed, t
 curl \
   -H 'Authorization: ...' \
   -X GET \
-  https://apps.akkeris.io/apps/event-perf-dev/app-setups
+  https://apps.akkeris.io/apps/app-space/app-setups
 ```
 
 **200 "Created" Response**
@@ -531,10 +532,10 @@ curl \
   "app": {
     "locked": false,
     "name": "event",
-    "organization": "performance",
+    "organization": "someorg",
     "region": "us-seattle",
     "personal": false,
-    "space": "perf-dev",
+    "space": "space",
     "stack": "ds1"
   },
   "env": {
@@ -572,18 +573,9 @@ curl \
     }
   },
   "addons": {
-    "platformjws-tokens": {
-      "plan": "platformjws-tokens:qa"
-    },
     "alamo-memcached": {
       "plan": "alamo-memcached:medium"
     },
-    "lang-db": {
-      "plan": "lang-db:dev"
-    },
-    "perf-db": {
-      "plan": "perf-db:dev"
-    }
   },
   "attachments": [],
   "source_blob": {
@@ -594,11 +586,11 @@ curl \
   "log-drains": [
     {
       "url": "syslog+tls://logs.app.com:40841",
-      "token": "event-perf-dev"
+      "token": "app-space"
     },
     {
-      "url": "syslog://metrics-syslog-collector-ds1.akkeris.io:9000",
-      "token": "event-perf-dev"
+      "url": "syslog://metrics.akkeris.io:9000",
+      "token": "app-space"
     }
   ],
   "pipeline-couplings": [],
@@ -2532,7 +2524,7 @@ Addons can be updated to promote (and subsequently demote) an addon of the same 
 curl \
   -H 'Authorization: ...' \
   -X PATCH \
-  https://apps.akkeris.io/apps/app-space/addons/mycoolname -d '{"primary":false, "attachment":{"name":"mynewcoolname"}}'
+  https://apps.akkeris.io/apps/app-space/addons/5feef9bb-2bed-4b62-bdf5-e31691fab88c -d '{"primary":false, "attachment":{"name":"mynewcoolname"}}'
 ```
 
 **200 "OK" Response**
@@ -2724,7 +2716,7 @@ Promote an addon attachment to the primary addon for its service type.
 curl \
   -H 'Authorization: ...' \
   -X PATCH \
-  https://apps.akkeris.io/apps/app-space/addon-attachments/myoldname -d '{"primary":false, "name":"mynewname"}'
+  https://apps.akkeris.io/apps/app-space/addon-attachments/5feef9bb-2bed-4b62-bdf5-e31691fab88c -d '{"primary":false, "name":"mynewname"}'
 ```
 
 **200 "OK" Response**
@@ -4234,7 +4226,11 @@ The following is fired to the webhook url during a release success or failure ev
     "description":"Auto Deploy of 31202984"
   },
   "build":{
-    "id":"8bdbac4b-6a5e-09e1-ef3a-08084a904622"
+    "id":"8bdbac4b-6a5e-09e1-ef3a-08084a904622",
+    "result":"succeeded",
+    "repo":"https://github.com/akkeris/foo.git",
+    "commit":"7edbac4b6a5e09e1ef3a08084a904621",
+    "branch":"master"
   }
 }
 ```
@@ -4261,6 +4257,7 @@ The following is fired to the webhook url during a build pending, success or fai
     "result":"pending|succeeded|failed",
     "created_at":"2016-08-09T12:00:00Z",
     "repo":"https://github.com/akkeris/bar.git",
+    "branch":"master",
     "commit":"7edbac4b6a5e09e1ef3a08084a904621"
   }
 }
@@ -4586,7 +4583,7 @@ This event occurs when an app has a new version and is now available for request
       "image":"docker.akkeris.io/org/yourappname-08b17a6f-f2e7-4698-b60a-6f89f6f2f00c:0.4",
       "source_blob":{  
          "checksum":"12345",
-         "url":"https://github.com/org/repo/commits/abcde3234fdsadf32342efasdf23432",
+         "url":null,
          "version":"Optional Version Info",
          "commit":"abcde3234fdsadf32342efasdf23432",
          "author":"John Smith",

--- a/lib/apps.js
+++ b/lib/apps.js
@@ -28,6 +28,7 @@ function app_payload_to_response(payload) {
     },
     "created_at":payload.created.toISOString(),
     "git_url":payload.repo,
+    "git_branch":payload.repo_branch,
     "id":payload.id,
     "maintenance":payload.disabled ? true : false,
     "name":payload.app_key,
@@ -180,6 +181,7 @@ async function create(pg_pool, org_key, space_key, app_name) {
   let payload = {
     created,
     repo:null,
+    repo_branch:null,
     id,
     app_uuid:id,
     disabled:false,

--- a/lib/previews.js
+++ b/lib/previews.js
@@ -59,7 +59,12 @@ async function create(pg_pool, source_app_uuid, foreign_key, suffix, additional_
       delete definition.env.PORT
     }
 
-    definition.env.PREVIEW_APP_SOURCE = {"description":"The app this preview app was generated from.", "required":true, "value":`${definition.app.name}-${definition.app.space}`}
+    // This must be set before the rename of the app.
+    definition.env.PREVIEW_APP_SOURCE = {
+      "description":"The app this preview app was generated from.", 
+      "required":false, 
+      "value":`${definition.app.name}-${definition.app.space}`
+    }
 
     // Unless were explicitly allowed to, 
     // blow away anything other than the web type for formations
@@ -83,6 +88,14 @@ async function create(pg_pool, source_app_uuid, foreign_key, suffix, additional_
 
     // create a unique name with suffix.
     definition.app.name = definition.app.name.substring(0, max_subdomain_length - (suffix.length + 1 + definition.app.space.length)) + suffix
+
+
+    definition.env.PREVIEW_APP = {
+      "description":"An indicator this app is a preview and the name of the app and space.", 
+      "required":false, 
+      "value":`${definition.app.name}-${definition.app.space}`
+    }
+
     // double check the unique name.
     let exists = false
     try {

--- a/lib/previews.js
+++ b/lib/previews.js
@@ -55,9 +55,11 @@ async function create(pg_pool, source_app_uuid, foreign_key, suffix, additional_
     }
 
     // Fitler out envs we cant allow
-    if(definition.env && definition.env.PORT) {
+    if(definition.env.PORT) {
       delete definition.env.PORT
     }
+
+    definition.env.PREVIEW_APP_SOURCE = {"description":"The app this preview app was generated from.", "required":true, "value":`${definition.app.name}-${definition.app.space}`}
 
     // Unless were explicitly allowed to, 
     // blow away anything other than the web type for formations

--- a/sql/select_app.sql
+++ b/sql/select_app.sql
@@ -15,13 +15,13 @@ select
   organizations.org org_uuid, 
   apps.url, 
   (select repo from auto_builds where apps.app = auto_builds.app and auto_builds.deleted = false limit 1) repo,
+  (select branch from auto_builds where apps.app = auto_builds.app and auto_builds.deleted = false limit 1) repo_branch,
   (select max(created) from releases where apps.app = releases.app limit 1) released,
   (select preview from previews where apps.app = previews.target and previews.deleted = false limit 1) preview
 from 
   apps 
     join spaces on apps.space = spaces.space 
     join organizations on apps.org = organizations.org
-    left join auto_builds on apps.app = auto_builds.app and auto_builds.deleted = false
     join stacks on spaces.stack = stacks.stack and stacks.deleted = false
     join regions on regions.region = stacks.region and regions.deleted = false
 where 

--- a/sql/select_apps.sql
+++ b/sql/select_apps.sql
@@ -15,6 +15,7 @@ select
   organizations.org org_uuid, 
   apps.url,
   (select repo from auto_builds where apps.app = auto_builds.app and auto_builds.deleted = false limit 1) repo,
+  (select branch from auto_builds where apps.app = auto_builds.app and auto_builds.deleted = false limit 1) repo_branch,
   (select max(created) from releases where apps.app = releases.app limit 1) released,
   (select preview from previews where apps.app = previews.target and previews.deleted = false limit 1) preview
 from 

--- a/sql/select_service_attachment.sql
+++ b/sql/select_service_attachment.sql
@@ -43,7 +43,6 @@ where
   service_attachments.deleted = false
   and (
         (apps.app::varchar(128) = $1 and (service_attachments.service_attachment::varchar(128) = $2 or service_attachments.name = $2)) or 
-        (service_attachments.service_attachment::varchar(128) = $1 and $2 is null) or 
-        (service_attachments.name = $1 and $2 is null) 
+        (service_attachments.service_attachment::varchar(128) = $1 and $2 is null)
       )
   and services.deleted = false

--- a/sql/select_service_attachment_owner.sql
+++ b/sql/select_service_attachment_owner.sql
@@ -22,6 +22,6 @@ from
   join spaces on spaces.space = apps.space and spaces.deleted = false
 where
   service_attachments.deleted = false
-  and (service_attachments.service::varchar(128) = $1 or service_attachments.name = $1)
+  and service_attachments.service::varchar(128) = $1
   and service_attachments.owned = true
   and service_attachments.deleted = false

--- a/test/addon-attachments.js
+++ b/test/addon-attachments.js
@@ -163,9 +163,9 @@ describe("addons attachments:", function() {
     expect(release_info).to.be.a('string');
   })
 
-  it("covers attaching memcachier to the second test app by name, ensures prod=prod apps can attach", async () => {
+  it("covers attaching memcachier to the second test app by id, ensures prod=prod apps can attach", async () => {
     expect(appname_second_id).to.be.a("string");
-    let data = await httph.request('post', 'http://localhost:5000/addon-attachments', alamo_headers, JSON.stringify({"addon":memcached_response.name, "app":appname_second_id, "force":true, "name":"memcachier"}));
+    let data = await httph.request('post', 'http://localhost:5000/addon-attachments', alamo_headers, JSON.stringify({"addon":memcached_response.id, "app":appname_second_id, "force":true, "name":"memcachier"}));
     expect(data).to.be.a('string');
     data = JSON.parse(data);
     memcached_addon_attachment_id = data.id;
@@ -185,10 +185,10 @@ describe("addons attachments:", function() {
     await httph.request('post', 'http://localhost:5000/apps/' + appname_third_new + '-preview/formation', alamo_headers, JSON.stringify({size:"constellation", quantity:1, "type":"web", port:5000}));
   });
 
-  it("covers attaching memcachier to the third test app by name, ensures prod!=non-prod apps can attach", async () => {
+  it("covers attaching memcachier to the third test app by id, ensures prod!=non-prod apps can attach", async () => {
     try {
       expect(appname_second_id).to.be.a("string");
-      let data = await httph.request('post', 'http://localhost:5000/addon-attachments', Object.assign({"x-silent-error":"true"}, alamo_headers), JSON.stringify({"addon":memcached_response.name, "app":appname_third_id, "name":"memcachier"}));
+      let data = await httph.request('post', 'http://localhost:5000/addon-attachments', Object.assign({"x-silent-error":"true"}, alamo_headers), JSON.stringify({"addon":memcached_response.id, "app":appname_third_id, "name":"memcachier"}));
       throw new Error('this should not have worked.');
     } catch (e) {
       expect(e.code).to.equal(409)

--- a/test/secure-key.js
+++ b/test/secure-key.js
@@ -62,7 +62,7 @@ describe("secure keys: creating, attaching and deleting", function() {
 
   let addon_attachment = null
   it("covers adding first secure key to second app", async () => {
-    addon_attachment = JSON.parse(await request('post', `http://localhost:5000/apps/${second_app}-preview/addon-attachments`, alamo_headers, JSON.stringify({"addon":addon.name, "app":`${second_app}-preview`, "force":true, "name":"securekey"})))
+    addon_attachment = JSON.parse(await request('post', `http://localhost:5000/apps/${second_app}-preview/addon-attachments`, alamo_headers, JSON.stringify({"addon":addon.id, "app":`${second_app}-preview`, "force":true, "name":"securekey"})))
     let config_vars = JSON.parse(await request('get', `http://localhost:5000/apps/${second_app}-preview/config-vars`, alamo_headers, null))
     expect(config_vars.SECURE_KEY).to.equal(addon.config_vars.SECURE_KEY)
     expect(config_vars.KEEP_ME).to.equal(unique_var2)


### PR DESCRIPTION
1. Disables being able to attach or detach an add-on by its name, as names are not globally unique. 
2. Cleans up some documentation stuff.
3. Fixes some tests that were trying to test name attachment of addons.
4. Adds some preview app environment variables to indicate if a preview app is one (I meant to add this on the last ticket but lost track of it.)