### PR TITLE
COBRA-2294b - release before passing processing off

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ let db_conf = {
   host:curl.hostname,
   database:((curl.path.indexOf('?') > -1) ? curl.path.substring(1,curl.path.indexOf("?")) : curl.path).replace(/^\//, ''),
   port:curl.port,
-  max:10,
+  max:40,
   idleTimeoutMillis:30000,
   ssl:false
 };

--- a/lib/query.js
+++ b/lib/query.js
@@ -9,12 +9,14 @@ async function query(query_statement, apply_func, pg_pool, parameters) {
     }
   })
   let client = await pg_pool.connect()
+  let final_result = []
   try {
     let result = await client.query(query_statement, parameters)
-    return apply_func ? result.rows.map(apply_func) : result.rows;
+    final_result = apply_func ? result.rows.map(apply_func) : result.rows;
   } finally {
     client.release()
   }
+  return final_result
 }
 
 module.exports = query;


### PR DESCRIPTION
Release pg pool thread before returning results, if the call stack exceeds 20 active pools things become serialized and can block. This could be the source of the timeouts, if they continue we'll need to dig deeper.